### PR TITLE
Decompressing fix

### DIFF
--- a/unpacker.cpp
+++ b/unpacker.cpp
@@ -21,6 +21,7 @@ void unpack(const string &file) {
 
         char *fileName = new char[fileNameLength + 1]; // +1 for '\0'
         input.read(fileName, fileNameLength);
+        fileName[fileNameLength] = '\0';
 
         cout << "Decompressing file " << fileName << "... ";
 
@@ -37,7 +38,7 @@ void unpack(const string &file) {
 
         output.close();
 
-        cout << "Done.";
+        cout << "Done." << endl;
 
         delete[] fileName;
     }

--- a/unpacker.cpp
+++ b/unpacker.cpp
@@ -19,9 +19,8 @@ void unpack(const string &file) {
     while (input.peek() != EOF) {
         unsigned int fileNameLength = readInt(input);
 
-        byte *fileNameBytes = new byte[fileNameLength];
-        input.read(reinterpret_cast<char *>(fileNameBytes), fileNameLength);
-        char *fileName(reinterpret_cast<char *>(fileNameBytes));
+        char *fileName = new char[fileNameLength + 1]; // +1 for '\0'
+        input.read(fileName, fileNameLength);
 
         cout << "Decompressing file " << fileName << "... ";
 
@@ -36,9 +35,11 @@ void unpack(const string &file) {
 
         decompress(codeStream, output);
 
+        output.close();
+
         cout << "Done.";
 
-        delete[] fileNameBytes;
+        delete[] fileName;
     }
 
     input.close();


### PR DESCRIPTION
File name string lacked '\0' which lead to file output streams not being opened & random extra characters in console when printing file's names.