### PR TITLE
Force output to console immediately

### DIFF
--- a/packer.cpp
+++ b/packer.cpp
@@ -35,6 +35,7 @@ void pack(const vector<string> &files, const string &outputFile) {
 
     for (const string &file : files) {
         cout << "Processing file " << file << "... ";
+        cout.flush();
 
         ifstream inputStream(file, ios::in | ios::binary);
         if (!inputStream.is_open()) {

--- a/unpacker.cpp
+++ b/unpacker.cpp
@@ -23,10 +23,12 @@ void unpack(const string &file) {
         fileName[fileNameLength] = '\0';
 
         cout << "Decompressing file " << fileName << "... ";
+        cout.flush();
 
         if (filesystem::exists(fileName)) {
             cerr << endl
                  << "File is not empty. Recreating it... ";
+            cerr.flush();
             filesystem::remove(fileName);
         }
 


### PR DESCRIPTION
Before this, when compressing/decompressing big files, `Compressing/Decompressing [filename]... ` hadn't been displayed until `Done\n` was printed.